### PR TITLE
fix(server): update artist model for mongoose 8.22.1 TypeScript compatibility

### DIFF
--- a/server/src/model/artist.ts
+++ b/server/src/model/artist.ts
@@ -1,6 +1,21 @@
 import mongoose from "../db/mongo";
 
-const artSchema = new mongoose.Schema(
+export interface art {
+  _id: string;
+  name: string;
+  year: number;
+  url: string;
+}
+
+export interface artist {
+  _id: string;
+  name: string;
+  url: string;
+  date: string;
+  art: art[];
+}
+
+const artSchema = new mongoose.Schema<art>(
   {
     _id: String,
     name: String,
@@ -9,7 +24,8 @@ const artSchema = new mongoose.Schema(
   },
   { _id: false }
 );
-const artistSchema = new mongoose.Schema(
+
+const artistSchema = new mongoose.Schema<artist>(
   {
     _id: String,
     name: String,
@@ -19,20 +35,5 @@ const artistSchema = new mongoose.Schema(
   },
   { _id: false }
 );
-
-export interface art {
-  _id: string;
-  name: string;
-  year: number;
-  url: string;
-}
-
-export interface artist extends mongoose.Document {
-  _id: string;
-  name: string;
-  url: string;
-  date: string;
-  art: art[];
-}
 
 export default mongoose.model<artist>("artist", artistSchema);


### PR DESCRIPTION
Move interfaces above schema declarations so they can be used as explicit
type parameters on Schema<T>, resolving the TS2590 union type complexity
error. Remove `extends mongoose.Document` from the artist interface since
mongoose 8.x no longer requires this and the newer Document type defaults
_id to ObjectId, conflicting with the string _id used here.

https://claude.ai/code/session_01Lsr1B5oTX5UUDcayY4WBEv