### PR TITLE
fix(ui): pin Node 20 in Netlify for @vitejs/plugin-react-swc v4

### DIFF
--- a/ui/netlify.toml
+++ b/ui/netlify.toml
@@ -1,3 +1,6 @@
+[build.environment]
+  NODE_VERSION = "20"
+
 [[headers]]
   for = "/*.js"
     [headers.values]


### PR DESCRIPTION
## Summary

- Adds `NODE_VERSION = "20"` to `ui/netlify.toml`

## Why

Dependabot PRs #93 and #99 both upgrade `@vitejs/plugin-react-swc` from v3 to v4 and `vite` from 6 to 8. These upgrades are valid and the GitHub Actions CI passes — but the Netlify deploy preview fails on all three checks ("Pages changed", "Redirect rules", "Header rules").

The root cause: **`@vitejs/plugin-react-swc` v4 requires Node 20.19+ or 22.12+**. Without an explicit `NODE_VERSION` in `netlify.toml`, Netlify's build environment falls back to an older default Node version and fails to build.

No vite config changes are needed — `vite.config.ts` is already compatible with Vite 8.

## After merging this PR

Rebase/update PR #99 (the vite 8.1.5 upgrade) against main and the Netlify deploy should go green.

https://claude.ai/code/session_01Lsr1B5oTX5UUDcayY4WBEv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lsr1B5oTX5UUDcayY4WBEv)_